### PR TITLE
[SCRUM-16] Quote remote kdump mv paths

### DIFF
--- a/SPECS/kexec-tools/dracut-kdump.sh
+++ b/SPECS/kexec-tools/dracut-kdump.sh
@@ -103,11 +103,20 @@ dump_raw()
     return 0
 }
 
+kdump_shell_quote()
+{
+    printf "'"
+    printf '%s' "$1" | sed "s/'/'\\\\''/g"
+    printf "'"
+}
+
 dump_ssh()
 {
     local _opt="-i $1 -o BatchMode=yes -o StrictHostKeyChecking=yes"
     local _dir="$KDUMP_PATH/$HOST_IP-$DATEDIR"
     local _host=$2
+    local _vmcore_incomplete
+    local _vmcore_flat
 
     echo "kdump: saving to $_host:$_dir"
 
@@ -124,7 +133,11 @@ dump_ssh()
         ssh $_opt $_host "mv $_dir/vmcore-incomplete $_dir/vmcore" || return 1
     else
         $CORE_COLLECTOR /proc/vmcore | ssh $_opt $_host "dd bs=512 of=$_dir/vmcore-incomplete" || return 1
-        ssh $_opt $_host "mv $_dir/vmcore-incomplete $_dir/vmcore.flat" || return 1
+        _vmcore_incomplete=$(kdump_shell_quote "$_dir/vmcore-incomplete")
+        _vmcore_flat=$(kdump_shell_quote "$_dir/vmcore.flat")
+        ssh $_opt $_host 'sh -s' <<EOF || return 1
+mv -- $_vmcore_incomplete $_vmcore_flat
+EOF
     fi
 
     echo "kdump: saving vmcore complete"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"972c6017-8e85-4391-bee8-a80b21a01c8d","source":"chat","resourceId":"9e9ae04d-21d3-4ac0-b219-523f8de00fd8","workflowId":"092d758f-d527-456e-a55d-020bf830ceb4","codeChangeId":"092d758f-d527-456e-a55d-020bf830ceb4","sourceType":"code_security_sast"} -->
###### Summary <!-- REQUIRED -->

Code Security (SAST) • [View in Code Security (SAST)](https://ap1.datadoghq.com/security/code-security/sast/vulnerability/009f278bec223e4c0e8864520646780c?column=score&order=desc&panel_event_id=AwAAAaABBgKbhZu5EwAAABhBYUFCQmdLYkFBQ19qTkdRNHpSU2pwZksAAAAkZjFhMDAxMGUtMjY2NS00NjI4LWEwMzctNDJhZDcxMGUzY2ViAAAZXg)

Fixes a CWE-78 risk in SPECS/kexec-tools/dracut-kdump.sh where the ssh remote mv command expanded the dump path locally inside a double-quoted remote command. The path is now quoted as remote shell data before being sent to the remote host.

###### Change Log  <!-- REQUIRED -->
- Added a POSIX shell quoting helper for remote command path operands.
- Updated the vmcore.flat remote rename path to run through single-quoted ssh sh -s input with shell-quoted source and destination paths.
- Limited the change to the reported ssh mv location.

###### Test Methodology
- Ran bash -n SPECS/kexec-tools/dracut-kdump.sh.
- Ran git diff --check.
- Verified the quoting helper round-trips path data containing spaces, semicolons, backticks, command substitution syntax, and single quotes.

###### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [x] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [x] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] If you are adding/removing a .spec file that has multiple-versions supported, please add @microsoft/cbl-mariner-multi-package-reviewers team as reviewer [(Eg. golang has 2 versions 1.18, 1.21+)](https://github.com/microsoft/azurelinux/tree/2.0/SPECS/golang)
- [x] Ready to merge

---

###### Does this affect the toolchain?  <!-- REQUIRED -->
**NO**

###### Associated issues  <!-- optional -->
None

###### Links to CVEs  <!-- optional -->
None

---

PR by Bits - [View session in Datadog](https://ap1.datadoghq.com/code/9e9ae04d-21d3-4ac0-b219-523f8de00fd8)